### PR TITLE
feat: add logo and responsive layout

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -37,7 +37,7 @@ jobs:
         # https://github.com/ruby/setup-ruby/releases/tag/v1.207.0
         uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4
         with:
-          ruby-version: '3.1' # Not needed with a .ruby-version file
+          ruby-version: '3.2' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Setup Pages

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,7 +8,7 @@
     {% endif %}
   </title>
 
-  <meta name="viewport" content="width=device-width, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <meta name="viewport" content="initial-scale=1" />
   <link rel="icon" href="/favicon.ico" type="image/x-icon" />
 
   <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,10 @@
 <header class="Header">
   <div class="Header-inner">
     <div class="Header-logo">
-      <a href="{{ '/' | relative_url }}">{{ site.data.settings.title }}</a>
+      <a href="{{ '/' | relative_url }}" aria-label="{{ site.data.settings.title }}">
+        <img src="{{ '/public/images/araucaria-logo.svg' | relative_url }}" alt="Logo {{ site.data.settings.title }}" class="Header-logo-image">
+        <span class="Header-logo-text">{{ site.data.settings.title }}</span>
+      </a>
     </div>
     <nav class="Header-nav">
       {% for item in site.data.settings.menu %}

--- a/assets/css/_footer.scss
+++ b/assets/css/_footer.scss
@@ -11,10 +11,23 @@
   &-inner {
     display: flex;
     justify-content: space-between;
+    align-items: center;
+    flex-direction: column;
+
+    @media (min-width: 450px) {
+      flex-direction: row;
+      align-items: flex-start;
+    }
 
     a {
       color: var(--font-color);
       opacity: 0.4;
+      margin-top: 1rem;
+      display: block;
+
+      @media (min-width: 450px) {
+        margin-top: 0;
+      }
 
       &:hover {
         color: var(--primary-color);

--- a/assets/css/_global.scss
+++ b/assets/css/_global.scss
@@ -10,6 +10,7 @@ html, body {
   line-height: 1.5;
   background-color: var(--background-color);
   color: var(--font-color);
+  min-width: 342px;
 
   @media (max-width: $large-screen) {
     font-size: 14px;

--- a/assets/css/_header.scss
+++ b/assets/css/_header.scss
@@ -1,5 +1,6 @@
 .Header {
   margin-bottom: 0.75rem;
+  position: relative;
 
   &-border {
     opacity: 0.4;
@@ -12,28 +13,84 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
+    padding: 1rem 0;
+    flex-direction: column;
+    max-width: 400px;
+    margin: 0 auto;
+
+    @media (min-width: 768px) {
+      max-width: 100%;
+      flex-direction: row;
+      padding: 0.5rem 0;
+    }
   }
 
   &-logo {
-    font-size: 2.2rem;
+    font-size: 1.6rem;
+    display: flex;
+    align-items: center;
+    position: relative;
+    margin-bottom: 1rem;
 
-    @media (max-width: $small-screen) {
-      font-size: 1.8rem;
+    @media (min-width: 768px) {
+      font-size: 2.2rem;
+      margin-bottom: 0;
+    }
+
+    a {
+      display: flex;
+      align-items: center;
+      text-decoration: none;
+    }
+  }
+
+  &-logo-image {
+    width: 30px;
+    height: auto;
+    position: absolute;
+    top: -5px;
+
+    @media (min-width: 768px) {
+      top: -2px
+    }
+  }
+
+  &-logo-text {
+    margin-left: 4rem;
+    font-size: 2.1rem;
+    @media (min-width: 768px) {
+      margin-left: 3.25rem;
     }
   }
 
   &-nav {
     display: flex;
-    font-size: 1.3rem;
+    font-size: 1.1rem;
+    align-items: center;
+    width: 100%;
+    justify-content: space-between;
+    margin-top: 0.5rem;
 
-    @media (max-width: $small-screen) {
-      font-size: 1.1rem;
+    @media (min-width: 768px) {
+      font-size: 1.3rem;
+      width: auto;
+      justify-content: flex-start;
+      margin-top: 0;
     }
 
     a {
       color: var(--font-color);
       opacity: 0.4;
-      margin-left: 1.5rem;
+      margin-right: 1rem;
+
+      @media (min-width: 768px) {
+        margin-right: 0;
+        margin-left: 1.5rem;
+      }
+
+      &:last-child {
+        margin-right: 0;
+      }
 
       &:hover {
         color: var(--primary-color);

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -36,6 +36,20 @@ $large-screen: 1024px;
 @import 'blog';
 @import 'theme';
 
+// Logo styles
+.Header-logo {
+  &-image {
+    height: 40px;
+    width: auto;
+    fill: $light-font-color;
+    stroke: $light-font-color;
+    
+    @media (max-width: $small-screen) {
+      height: 30px;
+    }
+  }
+}
+
 // Theme styles
 :root {
   --primary-color: #{$light-primary-color};
@@ -47,6 +61,11 @@ $large-screen: 1024px;
   --primary-color: #{$dark-primary-color};
   --background-color: #{$dark-background-color};
   --font-color: #{$dark-font-color};
+
+  .Header-logo-image {
+    fill: $dark-font-color;
+    stroke: $dark-font-color;
+  }
 
   pre, code {
     background-color: #1e1e1e;

--- a/public/images/araucaria-logo.svg
+++ b/public/images/araucaria-logo.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="200" height="250" viewBox="0 0 200 250" xmlns="http://www.w3.org/2000/svg">
+    <!-- Tronco principal -->
+    <path d="M95 250 L105 250 L105 80 L95 80 Z" fill="#FF9900"/>
+    
+    <!-- Galhos principais horizontais -->
+    <path d="M100 90 L180 90 L180 95 L100 95" stroke="#FF9900" stroke-width="5" fill="none"/>
+    <path d="M100 90 L20 90 L20 95 L100 95" stroke="#FF9900" stroke-width="5" fill="none"/>
+    
+    <path d="M100 130 L150 130 L150 135 L100 135" stroke="#FF9900" stroke-width="5" fill="none"/>
+    <path d="M100 130 L50 130 L50 135 L100 135" stroke="#FF9900" stroke-width="5" fill="none"/>
+    
+    <!-- <path d="M100 170 L130 170 L130 175 L100 175" stroke="#FF9900" stroke-width="5" fill="none"/>
+    <path d="M100 170 L70 170 L70 175 L100 175" stroke="#FF9900" stroke-width="5" fill="none"/> -->
+    
+    <!-- Círculos da copa -->
+    <circle cx="180" cy="92" r="20" fill="#FF9900"/>
+    <circle cx="20" cy="92" r="20" fill="#FF9900"/>
+    
+    <circle cx="150" cy="132" r="18" fill="#FF9900"/>
+    <circle cx="50" cy="132" r="18" fill="#FF9900"/>
+    
+    <!-- <circle cx="130" cy="172" r="16" fill="#FF9900"/>
+    <circle cx="70" cy="172" r="16" fill="#FF9900"/> -->
+    
+    <!-- Copa superior -->
+    <circle cx="100" cy="60" r="22" fill="#FF9900"/>
+    
+    <!-- Sombra na base -->
+    <ellipse cx="100" cy="250" rx="25" ry="15" fill="#FF9900" opacity="1"/>
+</svg> 


### PR DESCRIPTION
# Viewport Scale Adjustment for Mobile Responsiveness

## Changes
- Updated viewport meta tag to handle mobile scaling for screens smaller than 420px
- Changed from `width=device-width` to `width=342` to ensure consistent layout
- Updated GH Workflow to match dependency compatibility

## Purpose
This change ensures that the website maintains a consistent layout and readability across all mobile devices, particularly on smaller screens. By setting a fixed viewport width of 342px, the content will automatically scale down on devices with smaller screens while maintaining its proportions and structure.

## Preview

https://github.com/user-attachments/assets/37c671bb-0f3a-44e5-b771-d4488e49d83d

## Impact
- Improved mobile user experience
- Better content readability on small screens
- Consistent layout across different devices
- No visual distortion or layout breaks on mobile