### PR TITLE
feat: adiciona menu de outras cidades

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -6,7 +6,7 @@ menu:
   - {name: 'Eventos', url: '/events'}
   # - {name: 'Blog', url: '/blog'}
   - {name: 'Meetup', url: 'https://www.meetup.com/curitiba-bitdevs/', external: true}
-  # - {name: 'Cities', url: '/cities'}
+  - {name: 'Outras Cidades', url: '/cities'}
 
 social:
   x:

--- a/cities.md
+++ b/cities.md
@@ -15,6 +15,7 @@ title: Outras Cidades
             <li><a href="https://floripabitdevs.org/" target="_blank" rel="noopener nofollow">Florianópolis</a></li>
             <li><a href="https://poabitdevs.org/" target="_blank" rel="noopener nofollow">Porto Alegre</a></li>
             <li><a href="https://saopaulobitdevs.org/" target="_blank" rel="noopener nofollow">São Paulo</a></li>
+            <li><a href="https://udibitdevs.org/" target="_blank" rel="noopener nofollow">Uberlândia</a></li>
         </ul>
     </div>
 

--- a/cities.md
+++ b/cities.md
@@ -1,49 +1,29 @@
 ---
 layout: default
+title: Outras Cidades
 ---
+<div class="Home">
+    <p class="Home-about">
+        O formato BitDevs se espalhou por várias cidades do Brasil. Se você estiver viajando ou quiser conhecer outras comunidades, aqui vai uma lista com alguns grupos ativos.
+    </p>
 
-As Bitcoin has grown, so too have the local communities of like minded enthusiasts who wish to learn from one another and connect on a deeper level. Each of these communities is unique in its own way, composed of individuals from all walks of life with different ideas about what Bitcoin is and what it is not. What it can do, and what it cannot. But no matter from what lense you view Bitcoin, you cannot escape certain shared beliefs, because without them Bitcoin would not exist. One most critical is that of open source software development––"standing on the shoulder's of giants"––a principle that enables the seemingly endless chain of novel insights from which Bitcoin and its future improvements are built.
+    <div class="Home-posts">
+        <h2 class="Home-posts-title">BitDevs em outras cidades do Brasil</h2>
+        <ul>
+            <li><a href="https://bhbitdevs.org/" target="_blank" rel="noopener nofollow">Belo Horizonte</a></li>
+            <li><a href="https://bitdevs.bsb.br/" target="_blank" rel="noopener nofollow">Brasília</a></li>
+            <li><a href="https://floripabitdevs.org/" target="_blank" rel="noopener nofollow">Florianópolis</a></li>
+            <li><a href="https://poabitdevs.org/" target="_blank" rel="noopener nofollow">Porto Alegre</a></li>
+            <li><a href="https://saopaulobitdevs.org/" target="_blank" rel="noopener nofollow">São Paulo</a></li>
+        </ul>
+    </div>
 
-Inspired by this very ethos, the BitDevs NYC community fostered an in-person environment where technically focused dialogue could be used as a way of testing ideas, just in the same way software protocols are challenged in open networks. Instead of organizing meetups exclusively around presentations and lectures, events were styled as Socratic Seminars, such that open discourse underpinned each event, inviting a collaborative spirit that reflected the base principles of the Bitcoin protocol and cypherpunk spirit.
-
-Over time, the concept of BitDevs and the associated Socratic Seminar event series have spread to other cities. While the NYC community was first to stumble upon these ideas, it holds no trademark, license, branding or creative direction over the use of these terms. BitDevs, like any piece of open source code with a liberal license, is free for anyone to use and adapt to their local communities.
-
-If you find yourself interested in tapping into your local Bitcoin community, we have put together a list here of meetups which are known to regularly host in-person [Socratic Seminars](https://bitdevs.org/about). We hope you are able to attend and leave with a deeper connection to and appreciation for the Bitcoin community. Please [open a PR](https://github.com/BitDevsNYC/BitDevsNYC.github.io) to add your city. 
-
-As a disclaimer, BitDevs NYC has no official associations with or oversight of these meetups. In some cases we have never even spoken to the organizers. An idea, much like a hash function, is one way. If you don't like what you see, feel free to [fork it](https://github.com/BitDevsNYC/BitDevsNYC.github.io/) and [run your own](https://bitdevs.org/running-a-great-socratic-seminar/).
-
-- [Amsterdam](https://bitdevsamsterdam.org/)
-- [Athens](https://bitdevs-athens.com/)
-- [Atlanta](https://atlbit.dev/)
-- [Austin](https://austinbitdevs.com/)
-- [Berlin](https://bitdevs.berlin/)
-- [Boston](https://bostonbitdevs.org/)
-- [Brasília](https://bitdevs.bsb.br)
-- [Chicago](https://chibitdevs.org/)
-- [Denver](http://denverbitdevs.com/)
-- [Guadalajara](https://bitdevs.btcgdl.com/)
-- [Honolulu](http://www.honolulubitdevs.com/)
-- [London](https://londonbitdevs.org/)
-- [Los Angeles](https://bitdevsla.org/)
-- [Louisville](https://loubitdevs.org/)
-- [Miami](https://miamibitdevs.org/)
-- [Minneapolis](https://bitdevsmpls.org)
-- [Nashville](https://nashbitdevs.org)
-- [Norfolk](https://norfolkbitdevs.org/)
-- [Oslo](https://www.meetup.com/bitcoin-developers-oslo/)
-- [Paris](https://twitter.com/bitdevsfr)
-- [Perth](https://perth.bitdevs.com.au/)
-- [Portland](https://www.meetup.com/portlandbitdevs/)
-- [Porto Alegre](https://poabitdevs.org/)
-- [Raleigh / Durham / Chapel Hill](https://trianglebitdevs.org/)
-- [San Francisco](https://www.sfbitcoindevs.org/)
-- [San Juan](https://sanjuanbitdevs.org/)
-- [San Salvador](https://bitdevelsalvador.com/)
-- [São Paulo](https://bitdevsportugues.org)
-- [Singapore](https://bitdevs.sg/)
-- [Sydney](https://bitcoinsydney.org)
-- [Taipei](https://bitdevs.tw/)
-- [Tampa](https://tampabitdevs.io/)
-- [Vancouver](https://bitdevs.ca/)
-- [Victoria](https://bitdevsvictoria.org/)
-- [Washington, D.C.](https://dcbitdevs.org/)
+    <div class="Home-posts">
+        <h2 class="Home-posts-title">BitDevs em outras cidades do mundo</h2>
+        <p>
+            <a href="https://bitdevs.org/cities" target="_blank" rel="noopener nofollow">
+                Ver a lista global mantida pelo BitDevs NYC
+            </a>
+        </p>
+    </div>
+</div>


### PR DESCRIPTION
## Resumo
- adiciona a aba `Outras Cidades` no menu principal
- cria/atualiza a página `/cities` com links para os outros BitDevs do Brasil
- mantém um link separado para a lista global do BitDevs NYC

## Validação
- `git diff --check`

Closes #49
