### PR TITLE
Add seminar 017 topics

### DIFF
--- a/_posts/2026-08-21-socratic-seminar-017.md
+++ b/_posts/2026-08-21-socratic-seminar-017.md
@@ -1,15 +1,10 @@
 ---
 layout: post
-published: false
+published: true
 type: socratic
 title: "Seminário Socrático 017"
-meetup: "https://www.meetup.com/pt-br/curitiba-bitdevs/events/XXX"
-evento_so: "https://evento.so/p/evt_XXXX"
+evento_so: "https://app.evento.so/e/evt_jXGqcga7bMVU8VP2"
 ---
-<!--- TODO: remove `published: false` when creating new socratic --->
-<!--- TODO: replace meetup link with https://www.meetup.com/pt-br/curitiba-bitdevs/events/<##replace##>/ --->
-<!--- TODO: replace evento link with https://evento.so/p/<##replace##>/ --->
-
 
 ## Avisos
 
@@ -27,32 +22,62 @@ evento_so: "https://evento.so/p/evt_XXXX"
 
 ## Warmup
 
-- []()
+- [Bitcoin post office page](https://bitcoin-mempool.netlify.app/)
+- [DuraShare: Backup Soberano de Bitcoin com Shamir](https://www.youtube.com/watch?v=joPEVzITwUk)
+- [DuraShare](https://github.com/GRIFORTIS/durashare)
 
 ## Bitcoin Core
 
-- []()
+- [Bitcoin mempool linearization](https://arxiv.org/abs/2607.23787)
+- [PR BIP 54 Bitcoin Consensus Fixes](https://x.com/darosior/status/2080659168097190123)
+- [Static builds test for Bitcoin Core](https://x.com/i/status/2088660803071209474)
 
 ## BIPs & Proposals
 
-- []()
+- [BIP-110 live status](https://bip110.orange.surf/live.html)
+- [BIP-110 Bitcoin branch stalls after two blocks as gap widens](https://cointelegraph.com/news/bitcoin-bip-110-branch-stalls-miner-support)
+- [Dashjr Eyes a Separate PoW Chain for BIP-110](https://x.com/BitcoinNewsCom/status/2086914083123765556)
+- [Luke Dashjr's New PoW Method Can Be Gamed](https://x.com/BitcoinNewsCom/status/2087170406742376509)
 
 ## Layer 2
 
-- []()
+- [L402](https://l402.space/)
+- [L402 site L2 agents](https://x.com/lightning/status/2082504543611322687)
+- [Ibis wallet v5.0-beta is coming this week with full L2 support for Ark](https://x.com/aeonBTC/status/2084405380411691451)
+- [Boltz disabled](https://x.com/Boltzhq/status/2084311537502630319)
+- [Zeus offline](https://x.com/ZeusLN/status/2085113369367871605)
+- [Zeus Post-Mortem: Security Update](https://x.com/ZeusLN/status/2088288883981087093)
+- [BTCPay Patch Closes a Lightning Macaroon Leak](https://x.com/BtcpayServer/status/2085865561137831938)
+- [lnp2pBot Shuts Down Under Sustained Attack Pressure](https://x.com/negrunch/status/2086896990256799795)
 
 ## Research & Security
 
-- []()
+- [Coldcard seeds generation vulnerability](https://x.com/i/status/2082958675975553224)
+- [Coldcard RNG follow-up](https://x.com/i/status/2082961993070247948)
+- [More Coldcard RNG topics](https://x.com/i/status/2083716607977967622)
+- [Gerando uma Frase Semente BIP39 com Dados de 20 Faces](https://drive.google.com/file/d/1Hk9RGCxDyflTx2kV48qMg8VyY_zJHFk7/view)
+- [Blockstream Jade guide to create a recovery phrase using dice](https://help.blockstream.com/blockstream-jade/add-more-security-functionality/create-a-recovery-phrase-using-dice)
+- [HW Entropy](https://x.com/the_smart_ape/status/2084265598368809390)
+- [Crypto-js low entropy RNG](https://x.com/i/status/2086915709079367868)
+- [AI reviews](https://x.com/i/status/2088046083280879974)
+- [AI reviews follow-up](https://x.com/i/status/2088290231250210827)
+- [Equipe de red team apoiada por IA identifica 85 vulnerabilidades críticas no ecossistema do Bitcoin](https://www.cointribune.com/pt-br/equipe-de-red-team-apoiada-por-ia-identifica-85-vulnerabilidades-criticas-no-ecossistema-do-bitcoin/)
+- [More on BTC red team](https://x.com/i/status/2086220411084103707)
+- [OpenSats Fast-Tracks Funding For Bitcoin Bug Hunters](https://opensats.org/blog/code-red-supporting-first-responders)
+- [Bitkey Patches Bug, Says No Funds Were Ever at Risk](https://bitkey.world/blog/relationship-enrollment-bug-in-bitkey)
 
 ## Releases
 
-- []()
+- [Krux sunset](https://x.com/odudex/status/2084762385282171215)
+- [Krux will continue](https://x.com/selfcustodykrux/status/2089184624060575749)
+- [payjoin-1.0.0](https://github.com/payjoin/rust-payjoin/releases/tag/payjoin-1.0.0)
 
 ## Mining
 
-- []()
+- [Bitcoiners Race to Claim .bitcoin Before Auction](https://x.com/wiz/status/2085029140453830725)
 
 ## Miscellaneous
 
-- []()
+- [GitHub organization owners can see contributor's country and even IP](https://stacker.news/items/1540052)
+- [Random, largest UTXO](https://x.com/i/status/2088272196036878668)
+- [@NVK acquires @Boltzhq](https://x.com/bitcoin_bugle/status/2087996554275684635)


### PR DESCRIPTION
## Summary

- publish the Seminário Socrático 017 post
- add the Evento registration link from the announcement
- fill the topic sections with suggestions collected in #63

Refs #63

## Validation

- `git diff --check`
- `make build`